### PR TITLE
Load images on scroll into canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,32 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Scroll Animate Example 1</title>
-    <script language="JavaScript" type="text/javascript" src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
-    <script src="./dist/scrollAnimate.min.js"></script>
-    <script src="/scroll-animate-branding.js"></script>
+    <script src="./scroll-animate-branding.js" defer></script>
     <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      * {
+        box-sizing: border-box;
+      }
       .section {
         background-color: rgb(181, 181, 255);
       }
-      .sticky-container {
-        margin-top: 250px;
-        padding-top: 20px;
-        height: 9580px;
+      .hero {
+        padding: 20px;
+        padding-bottom: 250px;
+      }
+      header,
+      footer {
+        padding: 20px;
         background-color: rgb(85, 85, 255);
+        color: white;
+      }
+      .sticky-container {
+        height: 9580px;
+        position: relative; /* NEEDED TO COMPUTE OFFSETS IN JS */
       }
       .sticky {
         position: sticky;
@@ -25,42 +39,21 @@
         background-color: white;
       }
       .image-container {
-        width: 900px;
-        height: 720px; /*Static height so the page does not change on animation load*/
+        margin: auto;
       }
     </style>
   </head>
   <body>
     <div class="section" data-scroll-container="null">
-      <p>Page Container of a ugly example</p>
+      <div class="hero">Hero</div>
+      <header>Header</header>
       <div class="sticky-container">
-        <p>Sticky container</p>
-        <div class="sticky">
+        <div class="sticky" id="sticky">
           <p>Sticky</p>
-          <div class="image-container" id="image-container"></div>
+          <canvas class="image-container" id="image-container" width="900" height="720"></canvas>
         </div>
       </div>
+      <footer>Footer</footer>
     </div>
-
-    <!--<script>
-      var $aContainer = document.getElementById("animation-container");
-      var aContainerRect = $aContainer.getBoundingClientRect();
-      var start = aContainerRect.top;
-      var length = aContainerRect.height + 100; //Height of the container plus a offset for better presentation
-      scrollAnimate({
-        frames: {
-          path: "frames/",
-          prefix: "Bolk_Branding",
-          extension: "png",
-          amount: 40,
-          pad: "0000"
-        },
-        parent: $aContainer,
-        scroll: {
-          start: start,
-          length: length
-        }
-      });
-    </script>-->
   </body>
 </html>

--- a/scroll-animate-branding.js
+++ b/scroll-animate-branding.js
@@ -1,4 +1,3 @@
-// Script based on https://levelup.gitconnected.com/how-to-create-frame-by-frame-moving-image-on-scroll-effect-30ce577c63c2
 // 1 to 151 => 00 - Sphere
 // 152 to 212 => 01 - Sphere to branding
 // 213 to 413 => 02 - Branding
@@ -8,17 +7,54 @@
 // 758 to 908 => 06 - Contents
 // 909 to 958 => 07 - Contents to portfolio
 
-// Global variable to control the scrolling behavior
-const step = 10; // For each 10px, change an image
-function trackScrollPosition() {
-  const y = window.scrollY;
-  const label = Math.min(Math.floor(y/10) + 1, 958); //Animate 200 images and change every 10 pixels
-  const imageToUse = [label];
-  // Change the background image
-  $('.image-container').css('background-image', `url('/images/sphere-bolk-${imageToUse}.png')`); // TODO: Add url before ${}
-}
-$(document).ready(()=>{
-  $(window).scroll(()=>{
-    trackScrollPosition();
-  })
-})
+const containerID = 'sticky';
+const animationID = 'image-container';
+const frames = 958;
+
+const { documentElement: page } = document;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById(containerID);
+  const animation = document.getElementById(animationID);
+  const animCtx = animation.getContext('2d');
+
+  let top = null;
+  let isAnimated = false;
+
+  function animate () {
+    const {
+      top: currentTop,
+      height: currentHeight,
+      offsetTop
+    } = container.getBoundingClientRect();
+
+    isAnimated = (top == currentTop);
+    top = currentTop;
+
+    if (!isAnimated) { return }
+
+    const timeline = page.getBoundingClientRect().height - currentHeight*2;
+    const steps = timeline / frames;
+    const distance = container.offsetTop;
+
+    const index = Math.min(Math.floor(distance / steps), frames);
+    draw(index);
+
+  }
+
+  function draw (index) {
+    const loader = new Image();
+    loader.addEventListener('load', () => {
+      animCtx.clearRect(0, 0, animation.width, animation.height);
+      animCtx.drawImage(loader, 0, 0);
+    });
+    loader.src = `./images/sphere-bolk-${index}.png`;
+  }
+
+  draw(1);
+
+  window.addEventListener('scroll', () => {
+    requestAnimationFrame(animate);
+  });
+
+});


### PR DESCRIPTION
Yo!

Je me suis un peu amusé pour avoir un JS qui détecte quand l'élément sticky devient stick, et déclenche l'anim à ce moment là. Elle s'appuie sur la position courante du scroll, en détectant la frame selon la hauteur du block stick au moment du redraw, donc si ta fenêtre se redimensionne, l'effet devrait suivre. Ça impose juste que le parent conteneur (`sticky-container` ici) soit en `position: relative`.

Pour éviter les glitchs de chargement, on passe par un canvas qui ne se redraw que quand l'image est chargée.

Pour les perfs, j'ai logé tout ça dans un `requestAnimationFrame`, mais ça charge quand même pas mal le CPU, donc à voir pour accélerer le rendu différemment, peut-être.

Tu dois avoir un souci dans la séquence des images qui ne se suivent pas toujours bien j'ai l'impression, ou certaines qui sont manquantes (la `415` par exemple).

Ça devrait te permettre de bien continuer à avancer :)